### PR TITLE
MQ-45 Add quote field to Match structure

### DIFF
--- a/src/.pylintrc
+++ b/src/.pylintrc
@@ -114,6 +114,9 @@ ignore-comments=yes
 # Ignore docstrings when computing similarities.
 ignore-docstrings=yes
 
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
 
 [BASIC]
 

--- a/src/.pylintrc
+++ b/src/.pylintrc
@@ -109,13 +109,10 @@ notes=FIXME,XXX,TODO
 min-similarity-lines=4
 
 # Ignore comments when computing similarities.
-ignore-comments=yes
+ignore-comments=no
 
 # Ignore docstrings when computing similarities.
 ignore-docstrings=yes
-
-# Ignore imports when computing similarities.
-ignore-imports=yes
 
 
 [BASIC]

--- a/src/apps/movie_quotes/domain/entities/Match.py
+++ b/src/apps/movie_quotes/domain/entities/Match.py
@@ -27,11 +27,11 @@ class Match(object):
     """
 
     @property
-    def id(self):
+    def id(self):           # pylint:disable=duplicate-code
         return self._id
 
     @property
-    def quote(self):
+    def quote(self):        # pylint:disable=duplicate-code
         return self._quote
 
     @property
@@ -51,11 +51,11 @@ class Match(object):
     def user_profile(self, user_profile):
         self._user_profile = user_profile
 
-    @id.setter
+    @id.setter              # pylint:disable=duplicate-code
     def id(self, id):
         self._id = id
 
-    @quote.setter
+    @quote.setter           # pylint:disable=duplicate-code
     def quote(self, quote):
         self._quote = quote
 

--- a/src/apps/movie_quotes/domain/entities/Match.py
+++ b/src/apps/movie_quotes/domain/entities/Match.py
@@ -4,8 +4,9 @@ from apps.movie_quotes.domain.entities.Subtitle import Subtitle
 # === Модель бизнес-логики для хранения пользовательской истории ===
 
 class Match(object):
-    def __init__(self, id=None, user_profile=None, movie=None, subtitles=None):
+    def __init__(self, id=None, quote=None, user_profile=None, movie=None, subtitles=None):
         self._id = id
+        self._quote = quote
         self._user_profile = user_profile
         self._movie = movie
         self._subtitles = subtitles
@@ -14,6 +15,8 @@ class Match(object):
     Поля Match:
     
     - id - идентификатор истории пользователя
+
+    - quote - строка запроса, введенная пользователем
     
     - user_profile - профиль пользователя
     
@@ -26,6 +29,10 @@ class Match(object):
     @property
     def id(self):
         return self._id
+
+    @property
+    def quote(self):
+        return self._quote
 
     @property
     def user_profile(self):
@@ -48,6 +55,10 @@ class Match(object):
     def id(self, id):
         self._id = id
 
+    @quote.setter
+    def quote(self, quote):
+        self._quote = quote
+
     @movie.setter
     def movie(self, movie):
         self._movie = movie
@@ -68,6 +79,7 @@ class Match(object):
     # Метод конвертации объекта Match в словарь
     def to_dict(self):
         data = {}
+        data["quote"] = self.quote
         data["movie"] = self.movie.to_dict()
 
         subtitles = []

--- a/src/apps/movie_quotes/domain/entities/Subtitle.py
+++ b/src/apps/movie_quotes/domain/entities/Subtitle.py
@@ -26,11 +26,11 @@ class Subtitle(object):
     """
 
     @property
-    def id(self):
+    def id(self):               # pylint:disable=duplicate-code
         return self._id
 
     @property
-    def quote(self):
+    def quote(self):            # pylint:disable=duplicate-code
         return self._quote
 
     @property
@@ -45,11 +45,11 @@ class Subtitle(object):
     def movie(self):
         return self._movie
 
-    @id.setter
+    @id.setter                  # pylint:disable=duplicate-code
     def id(self, id):
         self._id = id
 
-    @quote.setter
+    @quote.setter               # pylint:disable=duplicate-code
     def quote(self, quote):
         self._quote = quote
 

--- a/src/apps/movie_quotes/domain/repositories/MatchRepo.py
+++ b/src/apps/movie_quotes/domain/repositories/MatchRepo.py
@@ -7,13 +7,13 @@ from apps.movie_quotes.domain.repositories.SubtitleRepo import SubtitleRepo
 from apps.movie_quotes.domain.repositories.UserProfileRepo import UserProfileRepo
 
 from apps.movie_quotes.infrastructure.django.models.MatchORM import MatchORM
+from apps.movie_quotes.utility.helpers import set_if_not_none
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import User
 
 from typing import List
 
-from apps.movie_quotes.utility.helpers import set_if_not_none
 
 # === Класс репозиторий истории пользователя ===
 
@@ -35,7 +35,7 @@ class MatchRepo:
                     sub = subtitle_repo.save(sub)
 
                 match_orm = MatchORM.objects.get(pk=match.id)
-                match_orm.quote = set_if_not_none(match.quote)
+                match_orm.quote = set_if_not_none(match_orm.quote, match.quote)
                 match_orm.save()
             else:
                 saved_match = self._create(match)

--- a/src/apps/movie_quotes/domain/repositories/MatchRepo.py
+++ b/src/apps/movie_quotes/domain/repositories/MatchRepo.py
@@ -13,6 +13,8 @@ from django.contrib.auth.models import User
 
 from typing import List
 
+from apps.movie_quotes.utility.helpers import set_if_not_none
+
 # === Класс репозиторий истории пользователя ===
 
 class MatchRepo:
@@ -31,6 +33,10 @@ class MatchRepo:
                 subtitle_repo = SubtitleRepo()
                 for sub in match.subtitles:
                     sub = subtitle_repo.save(sub)
+
+                match_orm = MatchORM.objects.get(pk=match.id)
+                match_orm.quote = set_if_not_none(match.quote)
+                match_orm.save()
             else:
                 saved_match = self._create(match)
 
@@ -80,6 +86,7 @@ class MatchRepo:
         user_profile_orm = UserProfileRepo.Mapper.from_domain(match.user_profile)
 
         created_match = MatchORM.objects.create(
+            quote=match.quote,
             user_profile=user_profile_orm,
             movie=movie_orm
         )
@@ -105,6 +112,7 @@ class MatchRepo:
 
             match_domain = Match(
                 id=match_orm.id,
+                quote=match_orm.quote,
                 user_profile=user_profile,
                 movie=movie_domain,
                 subtitles=subtitles_domain
@@ -124,5 +132,5 @@ class MatchRepo:
 
 class NoUserDefinedForMatch(Exception):
     def __init__(self, message=''):
-        super().__init__("Can't save match in the database \
-                          without user_profile link" + message)
+        super().__init__("Can't save match in the database "
+                         "without user_profile link" + message)

--- a/src/apps/movie_quotes/domain/usecases/SearchByQuoteUsecase.py
+++ b/src/apps/movie_quotes/domain/usecases/SearchByQuoteUsecase.py
@@ -18,6 +18,8 @@ class SearchByQuoteUsecase:
             return []
 
         matches = self._pack_subtitles_into_matches(subtitles)
+        for match in matches:
+            match.quote = self._quote
 
         return matches
 

--- a/src/apps/movie_quotes/infrastructure/django/models/MatchORM.py
+++ b/src/apps/movie_quotes/infrastructure/django/models/MatchORM.py
@@ -13,6 +13,8 @@ class MatchORM(models.Model):
     """
     Модель MatchORM несет информацию об истории пользователя и содержит следующие поля:
     
+    - quote - строка запроса, которую ввел пользователь
+
     - movie - название фильма, который был просмотрен пользователем
     
     - subtitles - субтитры
@@ -20,6 +22,7 @@ class MatchORM(models.Model):
     - user_profile - пользователь
     """
 
+    quote = models.CharField(max_length=200, null=False)
     movie = models.ForeignKey(MovieORM, null=False, on_delete=models.CASCADE)
     subtitles = models.ManyToManyField(SubtitleORM)
     user_profile = models.ForeignKey(UserProfileORM, on_delete=models.CASCADE)

--- a/src/apps/movie_quotes/tests/integration/domain/usecases/testSearchByQuoteUsecase.py
+++ b/src/apps/movie_quotes/tests/integration/domain/usecases/testSearchByQuoteUsecase.py
@@ -102,6 +102,7 @@ class TestSearchByQuoteUsecase(TestCase):
 
         expected_matches= [
             Match(
+                quote=quote,
                 movie=self.movie_1,
                 subtitles=[
                     self.sub_1_movie_1,
@@ -110,6 +111,7 @@ class TestSearchByQuoteUsecase(TestCase):
             ),
 
             Match(
+                quote=quote,
                 movie=self.movie_2,
                 subtitles=[
                     self.sub_5_movie_2
@@ -133,6 +135,7 @@ class TestSearchByQuoteUsecase(TestCase):
 
         expected_matches= [
             Match(
+                quote=quote,
                 movie=self.movie_1,
                 subtitles=[
                     self.sub_2_movie_1
@@ -140,6 +143,7 @@ class TestSearchByQuoteUsecase(TestCase):
             ),
 
             Match(
+                quote=quote,
                 movie=self.movie_2,
                 subtitles=[
                     self.sub_4_movie_2
@@ -179,6 +183,7 @@ class TestSearchByQuoteUsecase(TestCase):
 
         expected_matches = [
             Match(
+                quote=quote,
                 movie=self.movie_2,
                 subtitles=[
                     self.sub_6_movie_2

--- a/src/apps/movie_quotes/tests/integration/domain/usecases/testUpdateUserHistoryUsecase.py
+++ b/src/apps/movie_quotes/tests/integration/domain/usecases/testUpdateUserHistoryUsecase.py
@@ -61,6 +61,7 @@ class TestUpdateUserHistoryUsecase(TestCase):
     def test__execute__history_empty(self):
         # Arrange
         match_to_save = Match(
+            quote='test',
             user_profile=self.user_profile_1,
             movie=self.movie_1,
             subtitles=[self.sub_1_movie_1, self.sub_2_movie_1]
@@ -91,6 +92,7 @@ class TestUpdateUserHistoryUsecase(TestCase):
         # Arrange
         # fill up the history
         match_1 = Match(
+            quote='test1',
             user_profile=self.user_profile_1,
             movie=self.movie_1,
             subtitles=[self.sub_1_movie_1, self.sub_2_movie_1])
@@ -98,6 +100,7 @@ class TestUpdateUserHistoryUsecase(TestCase):
 
 
         match_2 = Match(
+            quote='test2',
             user_profile=self.user_profile_1,
             movie=self.movie_1,
             subtitles=[self.sub_1_movie_1])
@@ -105,6 +108,7 @@ class TestUpdateUserHistoryUsecase(TestCase):
 
         # Act
         match_to_save = Match(
+            quote='test3',
             user_profile=self.user_profile_1,
             movie=self.movie_1,
             subtitles=[self.sub_1_movie_1, self.sub_3_movie_1]

--- a/src/apps/movie_quotes/tests/unit/domain/serializers/testMatchSerialzer.py
+++ b/src/apps/movie_quotes/tests/unit/domain/serializers/testMatchSerialzer.py
@@ -33,6 +33,7 @@ class TestMatchSerializer(TestCase):
         cls.sub_2 = SubtitleRepo().get(subtitle_orm2.id)
 
         cls.match = Match(
+            quote='test quote',
             movie=cls.movie_1,
             subtitles=[cls.sub_1, cls.sub_2]
         )
@@ -42,7 +43,7 @@ class TestMatchSerializer(TestCase):
 
     def test__serialize_match(self):
         # Arrange
-        expected_json = '{"movie": {"id": "1", "title": "bomonka1", \
+        expected_json = '{"quote": "test quote", "movie": {"id": "1", "title": "bomonka1", \
 "year": "2001", "director": "me", \
 "poster": "https://bmstu.ru", "url": "https://bmstu.ru/poster.png"}, \
 "quotes": [{"id": "1", "quote": "Monday is a bad day!!!", "time": "00:00:37.673000"}, \

--- a/src/apps/movie_quotes/tests/unit/infrastructure/repositories/testMatchRepo.py
+++ b/src/apps/movie_quotes/tests/unit/infrastructure/repositories/testMatchRepo.py
@@ -58,6 +58,7 @@ class TestMatchRepo(TestCase):
     def test__Mapper__to_domain(self):
        # Arrange
         match_orm = MatchORM.objects.create(
+            quote='test',
             movie=self.movie_orm,
             user_profile=self.user_profile_orm
         )
@@ -66,6 +67,7 @@ class TestMatchRepo(TestCase):
 
         expected_match = Match(
             id=match_orm.id,
+            quote='test',
             user_profile=self.user_profile,
             movie=self.movie,
             subtitles=[self.sub_2, self.sub_1]
@@ -167,6 +169,7 @@ class TestMatchRepo(TestCase):
     def test__save__should_create_a_new_object(self):
         # Arrange
         match = Match(
+            quote='test',
             user_profile=self.user_profile,
             movie=self.movie,
             subtitles=[
@@ -176,6 +179,7 @@ class TestMatchRepo(TestCase):
         )
 
         expected_match_data = {
+            'quote': 'test',
             'user_profile': self.user_profile,
             'movie': self.movie,
             'subtitles_ids': [self.sub_2, self.sub_1]
@@ -185,6 +189,7 @@ class TestMatchRepo(TestCase):
         match_repo = MatchRepo()
         actual_match = match_repo.save(match)
         actual_match_data = {
+            'quote': actual_match.quote,
             'user_profile': actual_match.user_profile,
             'movie': actual_match.movie,
             'subtitles_ids': actual_match.subtitles


### PR DESCRIPTION
To determine which user request the Match was formed for, it was necessary
to add the appropriate field (quote) to the Match structure.